### PR TITLE
flatpak + some metainfo upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "observatory"
 version = "0.1.0"
 edition = "2021"
+license = "GPL-3.0-only"
+repository = "https://github.com/cosmic-utils/observatory.git"
 
 [dependencies]
 raw-cpuid = "11.2.0"

--- a/README.md
+++ b/README.md
@@ -1,43 +1,54 @@
 <div align="center">
-  <img src="res/icons/hicolor/scalable/apps/icon.svg" width="150" />
+  <img src="res/icons/hicolor/scalable/apps/icon.svg" width="300" />
   <h1>Observatory</h1>
-
   <p>An in-development system monitor application for the COSMIC™ desktop environment</p>
+  <a href="https://flathub.org/apps/io.github.cosmic_utils.observatory"><img src="https://flathub.org/api/badge?svg&locale=en" /></a>
+  
+  <br/><br/>
 
   ![Screenshot of the observatory app's processes page](res/screenshots/disk-light.png#gh-light-mode-only)
   ![Screenshot of the observatory app's processes page](res/screenshots/disk-dark.png#gh-dark-mode-only)
+
 </div>
 
 # Features
+
 View information about your system.
 
 ## CPU
+
 View usage per core, threads, processes handles, up time, speed and total usage.
 
 ![CPU Light](res/screenshots/processor-light.png#gh-light-mode-only)
-![CPU Dark](res/screenshots/processor-dark.png#gh-dark-mode-only)
+![CPU Dark](res/screenshots/processor-dark.png#gh-dark-mode-only)u
 
 ## Memory
+
 View total memory and swap usage.
 
 ![Memory Light](res/screenshots/memory-light.png#gh-light-mode-only)
 ![Memory Dark](res/screenshots/memory-dark.png#gh-dark-mode-only)
 
 ## Disk usage
+
 View usage per disk and total read and write.
 
 ![Disk Light](res/screenshots/disk-light.png#gh-light-mode-only)
-![Disks Dark](res/screenshots/disk-dark.png#gh-dark-mode-only)
+![Disk Dark](res/screenshots/disk-dark.png#gh-dark-mode-only)
 
 ## Processes
+
 View and manage running processes on your system.
 
-![Disk Light](res/screenshots/processes-light.png#gh-light-mode-only)
-![Disks Dark](res/screenshots/processes-dark.png#gh-dark-mode-only)
+![Processes Light](res/screenshots/processes-light.png#gh-light-mode-only)
+![Processes Dark](res/screenshots/processes-dark.png#gh-dark-mode-only)
 
 ## Installation
+
 To install, clone this repository and run the following command:
+
 ```
 sudo just install
 ```
+
 make sure you have `just` installed on your system

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ View information about your system.
 View usage per core, threads, processes handles, up time, speed and total usage.
 
 ![CPU Light](res/screenshots/processor-light.png#gh-light-mode-only)
-![CPU Dark](res/screenshots/processor-dark.png#gh-dark-mode-only)u
+![CPU Dark](res/screenshots/processor-dark.png#gh-dark-mode-only)
 
 ## Memory
 

--- a/io.github.cosmic_utils.observatory.json
+++ b/io.github.cosmic_utils.observatory.json
@@ -1,0 +1,41 @@
+{
+  "id": "io.github.cosmic_utils.observatory",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "24.08",
+  "base": "com.system76.Cosmic.BaseApp",
+  "base-version": "stable",
+  "sdk": "org.freedesktop.Sdk",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+  "command": "cosmic-ext-tweaks",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--talk-name=com.system76.CosmicSettingsDaemon"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/rust-stable/bin",
+    "env": {
+      "CARGO_HOME": "/run/build/observatory/cargo"
+    }
+  },
+  "modules": [
+    {
+      "name": "observatory",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cargo --offline build --release --verbose",
+        "just prefix=/app install "
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/cosmic-utils/observatory.git",
+          "commit": ""
+        },
+        "cargo-sources.json"
+      ]
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -1,20 +1,23 @@
 name := 'observatory'
-appid := 'org.cosmic-utils.Observatory'
+appid := 'io.github.cosmic_utils.observatory'
 
 rootdir := ''
 prefix := '/usr'
 
 base-dir := absolute_path(clean(rootdir / prefix))
+share-dir := base-dir / 'share'
 
 bin-src := 'target' / 'release' / name
 bin-dst := base-dir / 'bin' / name
 
 desktop := appid + '.desktop'
 desktop-src := 'res' / desktop
-desktop-dst := clean(rootdir / prefix) / 'share' / 'applications' / desktop
+desktop-dst := share-dir / 'applications' / desktop
+
+metainfo-dst := share-dir / 'metainfo' / appid + '.xml'
 
 icons-src := 'res' / 'icons' / 'hicolor'
-icons-dst := clean(rootdir / prefix) / 'share' / 'icons' / 'hicolor'
+icons-dst := share-dir / 'icons' / 'hicolor'
 
 icon-svg-src := icons-src / 'scalable' / 'apps' / 'icon.svg'
 icon-svg-dst := icons-dst / 'scalable' / 'apps' / appid + '.svg'
@@ -59,10 +62,11 @@ install:
     install -Dm0755 {{bin-src}} {{bin-dst}}
     install -Dm0644 res/app.desktop {{desktop-dst}}
     install -Dm0644 {{icon-svg-src}} {{icon-svg-dst}}
+    install -Dm0644 res/metainfo.xml {{metainfo-dst}}
 
 # Uninstalls installed files
 uninstall:
-    rm {{bin-dst}} {{desktop-dst}} {{icon-svg-dst}}
+    rm {{bin-dst}} {{desktop-dst}} {{icon-svg-dst}} {{metainfo-dst}}
 
 # Vendor dependencies locally
 vendor:

--- a/res/app.desktop
+++ b/res/app.desktop
@@ -1,12 +1,16 @@
 [Desktop Entry]
 Name=Observatory
+
 Comment=System Monitor application for the COSMIC Desktop
-Exec=observatory %F
+Comment[fr]=Gestionnaire de tâche pour le COSMIC Desktop
+
+Keywords=system;monitor;task;manager;resource
+Keywords[fr]=gestionnaire;tache;manager;ressource
+
+Exec=observatory
 Terminal=false
 Type=Application
 StartupNotify=true
-Icon=org.cosmic-utils.Observatory
-StartupWMClass=org.cosmic-utils.Observatory
-Categories=COSMIC;
-Keywords=
-MimeType=
+Icon=io.github.cosmic_utils.observatory
+StartupWMClass=io.github.cosmic_utils.observatory
+Categories=System;Utility;

--- a/res/metainfo.xml
+++ b/res/metainfo.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.cosmic_utils.observatory</id>
+  <name>Observatory</name>
+  <summary>System Monitor application for the COSMIC Desktop</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <project_group>COSMIC</project_group>
+  <developer id="io.github">
+    <name>Adam Cosner</name>
+  </developer>
+  <url type="homepage">https://github.com/cosmic-utils/observatory</url>
+  <url type="bugtracker">https://github.com/cosmic-utils/observatory/issues</url>
+  <url type="vcs-browser">https://github.com/cosmic-utils/observatory</url>
+  <content_rating type="oars-1.1" />
+  <description>
+    <p>Feature full System Monitor application</p>
+    <ul>
+      <li>View usage per core, threads, processes handles, up time, speed and total usage.</li>
+      <li>View total memory and swap usage.</li>
+      <li>View usage per disk and total read and write.</li>
+      <li>View and manage running processes on your system.</li>
+    </ul>
+  </description>
+  <!-- <branding>
+    <color type="primary" scheme_preference="light">#8affe1</color>
+    <color type="primary" scheme_preference="dark">#007d5c</color>
+  </branding> -->
+  <launchable type="desktop-id">io.github.cosmic_utils.observatory.desktop</launchable>
+  <icon type="remote" height="256" width="256">https://raw.githubusercontent.com/cosmic-utils/observatory/main/res/icons/hicolor/scalable/apps/icon.svg</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/cosmic-utils/observatory/main/res/screenshots/processor-dark.png</image>
+      <caption>CPU Dark</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/cosmic-utils/observatory/main/res/screenshots/memory-dark.png</image>
+      <caption>Memory Dark</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/cosmic-utils/observatory/main/res/screenshots/disks-dark.png</image>
+      <caption>Disks Dark</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/cosmic-utils/observatory/main/res/screenshots/processes-dark.png</image>
+      <caption>Processes Dark</caption>
+    </screenshot>
+  </screenshots>
+  
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <provides>
+    <id>com.system76.CosmicApplication</id>
+  </provides>
+  <releases>
+    <release version="0.1.0" date="2024-09-30">
+      <description>
+        <p>Initial release! &#x1f389;</p>
+        <ul>
+          <li>Save current color scheme</li>
+          <li>Import existing color schemes</li>
+          <li>Download color schemes from cosmic-themes.org</li>
+          <li>Customize the panel and dock</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,7 +53,7 @@ impl cosmic::Application for App {
     type Message = Message;
 
     /// The unique application ID to supply to the window manager.
-    const APP_ID: &'static str = "org.cosmic-utils.Observatory";
+    const APP_ID: &'static str = "io.github.cosmic_utils.observatory";
 
     fn core(&self) -> &Core {
         &self.core


### PR DESCRIPTION
This create a `io.github.cosmic_utils.observatory.json` manifest to build a flatpak package. The appid was changed to follow the flathub requirement (https://docs.flathub.org/docs/for-app-authors/requirements/)

Now, to upload this app to flathub, you must create a PR to https://github.com/flathub/flathub, and include the manifest + the generated `cargo-sources.json` file (not included in this PR to not polute the repo (btw, better to use git-lfs for .png).

To generate, execute in the repo

```
git clone https://github.com/flatpak/flatpak-builder-tools
python3 flatpak-builder-tools/cargo/flatpak-cargo-generator.py Cargo.lock -o cargo-sources.json
```
- You will also need to change the "commit: " field in the manifest (you can use a commit of this pr for now if you want).
- the release section in the metainfo will also need to be changed (it is a required for submitting a flatpak app)

let me know if you have any questions